### PR TITLE
feat: allow absolute paths in imports

### DIFF
--- a/components/Image.tsx
+++ b/components/Image.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import NextImage from 'next/image';
 import { Avatar, Theme } from '@mui/material';
 import { createStyles, makeStyles } from '@mui/styles';
-import { Maybe } from '../types/gen/graphql-types';
+import { Maybe } from 'types/gen/graphql-types';
 
 interface Props {
     image: Maybe<string> | undefined;

--- a/components/dialog/ToolDialog.tsx
+++ b/components/dialog/ToolDialog.tsx
@@ -3,8 +3,8 @@ import { Tool } from '@prisma/client';
 import gql from 'graphql-tag';
 import React, { ReactElement } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { useCreateToolMutation } from '../../types/gen/graphql-types';
-import { QUERY_TOOLS } from '../../pages';
+import { useCreateToolMutation } from 'types/gen/graphql-types';
+import { QUERY_TOOLS } from 'pages/index';
 
 interface Props {
     open: boolean;

--- a/components/list/ListItem.tsx
+++ b/components/list/ListItem.tsx
@@ -2,7 +2,7 @@ import { ListItem as MUIListItem, ListItemAvatar, Avatar, ListItemText, Grid, Ty
 import { makeStyles, createStyles } from '@mui/styles';
 import Image from '../Image';
 import Link from '../link/Link';
-import { Maybe } from '../../types/gen/graphql-types';
+import { Maybe } from 'types/gen/graphql-types';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,6 +11,12 @@ const config: Config.InitialOptions = {
     },
     testEnvironment: 'jsdom',
     moduleNameMapper: {
+        '^components/(.*)$': '<rootDir>/components/$1',
+        '^lib/(.*)$': '<rootDir>/lib/$1',
+        '^pages/(.*)$': '<rootDir>/pages/$1',
+        '^services/(.*)$': '<rootDir>/services/$1',
+        '^tests/(.*)': '<rootDir>/tests/$1',
+        '^types/(.*)$': '<rootDir>/types/$1',
         '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
     },
     verbose: true,

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,6 +1,6 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheets } from '@mui/styles';
-import theme from '../lib/theme';
+import theme from 'lib/theme';
 import React from 'react';
 
 // Fixes SSR with Material UI styles - https://developerhandbook.com/react/how-to-set-up-nextjs-material-ui/

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,11 +2,11 @@ import { Typography, Theme, List, Grid, Button } from '@mui/material';
 import { makeStyles, createStyles } from '@mui/styles';
 import { useState } from 'react';
 import { gql } from '@apollo/client';
-import Layout from '../components/layout';
-import ToolDialog from '../components/dialog/ToolDialog';
-import { useToolsQuery } from '../types/gen/graphql-types';
-import ListItem from '../components/list/ListItem';
-import { LinkProps } from '../components/link/Link';
+import Layout from 'components/layout';
+import ToolDialog from 'components/dialog/ToolDialog';
+import { useToolsQuery } from 'types/gen/graphql-types';
+import ListItem from 'components/list/ListItem';
+import { LinkProps } from 'components/link/Link';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({

--- a/pages/tool/[id].tsx
+++ b/pages/tool/[id].tsx
@@ -3,10 +3,10 @@ import { makeStyles } from '@mui/styles';
 import Link from 'next/link';
 import { ReactElement } from 'react';
 import { useRouter } from 'next/router';
-import Layout from '../../components/layout';
-import Image from '../../components/Image';
+import Layout from 'components/layout';
+import Image from 'components/Image';
 import gql from 'graphql-tag';
-import { useToolQuery } from '../../types/gen/graphql-types';
+import { useToolQuery } from 'types/gen/graphql-types';
 
 const useStyles = makeStyles((theme: Theme) => ({
     description: {

--- a/tests/components/Layout.test.tsx
+++ b/tests/components/Layout.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '../test-utils';
-import Layout from '../../components/layout';
+import Layout from 'components/layout';
 
 describe('Home page', () => {
     it('should render without errors', async () => {

--- a/tests/pages/Home.test.tsx
+++ b/tests/pages/Home.test.tsx
@@ -1,7 +1,7 @@
 // you want to import from test-utils instead of testing-library/react since we overwrote the render function to support our wrapper providers
 import { render, screen, waitFor } from '../test-utils';
-import Home, { QUERY_TOOLS } from '../../pages/index';
-import { tools } from '../../lib/tools';
+import Home, { QUERY_TOOLS } from 'pages/index';
+import { tools } from 'lib/tools';
 
 const mocks = [
     {

--- a/tests/pages/Tool.test.tsx
+++ b/tests/pages/Tool.test.tsx
@@ -1,7 +1,7 @@
 // you want to import from test-utils instead of testing-library/react since we overwrote the render function to support our wrapper providers
 import { render, screen, waitFor } from '../test-utils';
-import Tool, { QUERY_TOOL } from '../../pages/tool/[id]';
-import { tools } from '../../lib/tools';
+import Tool, { QUERY_TOOL } from 'pages/tool/[id]';
+import { tools } from 'lib/tools';
 
 describe('Tool Page', () => {
     it('should render  a page without errors', async () => {

--- a/tests/test-utils.tsx
+++ b/tests/test-utils.tsx
@@ -7,7 +7,7 @@ import { NextRouter } from 'next/router';
 import { ThemeProvider, StyledEngineProvider } from '@mui/material';
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 
-import theme from '../lib/theme';
+import theme from 'lib/theme';
 
 export * from '@testing-library/react';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "allowJs": true,
         "alwaysStrict": true,
+        "baseUrl": ".",
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "isolatedModules": true,


### PR DESCRIPTION
Allow absolute path imports. See tsconfig.json and jest.config.ts for the magic.

I'd appreciate someone testing this one. The tests run fine after the change, but I didn't setup a database or create any models so I'm not certain the prisma stuff is all still working.